### PR TITLE
Cleanup additional space and stop removing swap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,12 +15,19 @@ jobs:
         deploytool: ['operator', 'helm']
         globalnet: ['', 'globalnet']
         cable_driver: ['libreswan', 'strongswan', 'wireguard']
+        ovn: ['', 'ovn']
         exclude:
           # Our Helm setup doesn’t know how to deploy other cable drivers
           - deploytool: 'helm'
             cable_driver: 'wireguard'
           - deploytool: 'helm'
             cable_driver: 'libreswan'
+          - ovn: 'ovn'
+            deploytool: 'helm'
+          - ovn: 'ovn'
+            globalnet: 'globalnet'
+          - ovn: 'ovn'
+            cable_driver: 'strongswan'
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
@@ -40,7 +47,7 @@ jobs:
 
       - name: Run E2E deployment and tests
         run: |
-          make e2e using="${{ matrix.globalnet }} ${{ matrix.deploytool }} ${{ matrix.cable_driver }}"
+          make e2e using="${{ matrix.globalnet }} ${{ matrix.deploytool }} ${{ matrix.cable_driver }} ${{ matrix.ovn }}"
 
       - name: Post mortem
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Reclaim free space
         run: |
-          # cleanup 30GB+ of tools we don't need for our CI
+          # cleanup 30GB+ of tools we don't need for our CI ... bump
           rm -rf /opt/ghc /usr/share/dotnet /usr/share/swift
           df -h
           free -h

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Reclaim free space
         run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
+          # cleanup 30GB+ of tools we don't need for our CI
+          rm -rf /opt/ghc /usr/share/dotnet /usr/share/swift
           df -h
           free -h
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@ include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e / -e reload-images)
 override BUILD_ARGS += $(shell source ${SCRIPTS_DIR}/lib/version; echo --ldflags \'-X main.VERSION=$${VERSION}\')
+
+ifneq (,$(filter ovn,$(_using)))
+override CLUSTERS_ARGS += --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings.ovn
+else
 override CLUSTERS_ARGS += --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings
+endif
+
 override E2E_ARGS += --focus $(focus) cluster2 cluster3 cluster1
 override UNIT_TEST_ARGS += test/e2e
 override VALIDATE_ARGS += --skip-dirs pkg/client

--- a/scripts/cluster_settings.ovn
+++ b/scripts/cluster_settings.ovn
@@ -1,0 +1,6 @@
+# Specific settings for the submariner E2E
+cluster_nodes['cluster1']="control-plane worker"
+cluster_nodes['cluster2']="control-plane worker worker"
+cluster_nodes['cluster3']="control-plane worker worker"
+
+cluster_cni=( ['cluster1']="ovn" ['cluster2']="ovn" ['cluster3']="ovn" )


### PR DESCRIPTION
There are 30GB+ of files in tools that we don't need or use
for building submariner, we mostly work inside of docker.
Those files are removed now.

Swap isn't disabled anymore, now GitHub uses a separate disk
for swap /dev/sdb instead of the main disk.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>